### PR TITLE
WheelView长字符串显示不全

### DIFF
--- a/wheelview/src/main/java/com/contrarywind/view/WheelView.java
+++ b/wheelview/src/main/java/com/contrarywind/view/WheelView.java
@@ -579,7 +579,7 @@ public class WheelView extends View {
             //设置2条横线中间的文字大小
             paintCenterText.setTextSize(size);
             paintCenterText.getTextBounds(contentText, 0, contentText.length(), rect);
-            width = rect.width();
+            width = rect.width() + rect.width() / contentText.length();
         }
         //设置2条横线外面的文字大小
         paintOuterText.setTextSize(size);


### PR DESCRIPTION
有时绘制长字符串最后一个文字会出现一丁点超出控件范围，eg: 州 字符，少了最后一竖。
这个简单修改可以避免这种情况，请作者参考一下。